### PR TITLE
Fixing Expose Port in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ LABEL shorturl.app main
 
 COPY --from=build /go/src/github.com/${REPO}/${APP} /${APP}
 
-EXPOSE 8080/tcp
+EXPOSE 8000/tcp
 
 ENTRYPOINT ["/shorturl"]
 CMD []


### PR DESCRIPTION
This fixes the docker build so it will expose the port that the go app is actually listening on. If you'd rather change the code to reference 8080 (the port referenced in the dockerfile) let me know. I'll update the pr with code changes.